### PR TITLE
Allow to pass in custom exception messages in NxtHttpClient::Error

### DIFF
--- a/lib/nxt_http_client/error.rb
+++ b/lib/nxt_http_client/error.rb
@@ -1,13 +1,18 @@
 module NxtHttpClient
   class Error < StandardError
-    def initialize(response)
+    def initialize(response, message = nil)
       @response = response.blank? ? Typhoeus::Response.new : response
       @id = SecureRandom.uuid
+      @message = message || default_message
+
+      super(@message)
     end
 
-    attr_reader :response, :id
+    attr_reader :response, :id, :message
 
-    def to_s
+    alias_method :to_s, :message
+
+    def default_message
       "NxtHttpClient::Error::#{response_code}"
     end
 

--- a/spec/callbacks_spec.rb
+++ b/spec/callbacks_spec.rb
@@ -75,9 +75,13 @@ RSpec.describe NxtHttpClient::Client do
     context ':error', :vcr_cassette do
       let(:client) do
         Class.new(NxtHttpClient::Client) do
+          def self.name
+            'Test Client'
+          end
+
           register_response_handler do |handler|
             handler.on(:error) do |response|
-              raise StandardError, 'Response not successful'
+              raise NxtHttpClient::Error.new(response, "#{self.class.name} => Response not successful")
             end
           end
         end
@@ -86,7 +90,7 @@ RSpec.describe NxtHttpClient::Client do
       it 'runs the error callback' do
         expect {
           subject.fire('www.f193a3d484c97517369fa15e6e586b44.com')
-        }.to raise_error StandardError, /Response not successful/
+        }.to raise_error NxtHttpClient::Error, 'Test Client => Response not successful'
       end
     end
 


### PR DESCRIPTION
This allows to pass custom messages to `NxtHttpClient::Errors`  

We could use this per nxt client so we can see in sentry directly which client is raising an error instead of always the same `NxtHttpClient::Error::XXX`