### PR TITLE
Loosen ActiveSupport version requirement to allow 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.3.4 2021-01-05
+
+### Updated
+
+- Loosen ActiveSupport version requirement to allow 6.1
+
 # v0.3.3 2020-09-30
 
 ### Updated NxtRegistry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    nxt_http_client (0.3.3)
-      activesupport (~> 6.0.0)
+    nxt_http_client (0.3.4)
+      activesupport (~> 6.0)
       nxt_registry
       typhoeus
 

--- a/lib/nxt_http_client/version.rb
+++ b/lib/nxt_http_client/version.rb
@@ -1,3 +1,3 @@
 module NxtHttpClient
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 end

--- a/nxt_http_client.gemspec
+++ b/nxt_http_client.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'typhoeus'
-  spec.add_dependency 'activesupport', '~> 6.0.0'
+  spec.add_dependency 'activesupport', '~> 6.0'
   spec.add_dependency 'nxt_registry'
 
   spec.add_development_dependency 'bundler', '~> 1.17'


### PR DESCRIPTION
The current version constraint is blocking the Rails 6.1 upgrade in all services. This will allow any ActiveSupport version below 7.