### PR TITLE
ED-158 Introduce a Typhoeus::Hydra interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.0.5 2023-04-03
+- Introduce a Typhoeus::Hydra interface for batch executions
+
 # v1.0.4 2022-06-08
 - Fix bug where callbacks were shared between unrelated child client class ([#130](https://github.com/nxt-insurance/nxt_http_client/pull/130))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.0.5 2023-04-03
+# v1.1.0 2023-04-03
 - Introduce a Typhoeus::Hydra interface for batch executions
 
 # v1.0.4 2022-06-08

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_http_client (1.0.4)
+    nxt_http_client (1.0.5)
       activesupport (< 8.0)
       nxt_registry
       typhoeus
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -17,18 +17,18 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
     ffi (1.15.5)
     hashdiff (1.0.1)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.15.0)
+    minitest (5.18.0)
     nxt_registry (0.3.10)
       activesupport
     nxt_vcr_harness (0.1.4)
@@ -59,7 +59,7 @@ GEM
     timecop (0.9.5)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     vcr (6.1.0)
     webmock (3.14.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_http_client (1.0.5)
+    nxt_http_client (1.1.0)
       activesupport (< 8.0)
       nxt_registry
       typhoeus

--- a/lib/nxt_http_client.rb
+++ b/lib/nxt_http_client.rb
@@ -11,6 +11,7 @@ require 'nxt_http_client/logger'
 require 'nxt_http_client/fire_callbacks'
 require 'nxt_http_client/client_dsl'
 require 'nxt_http_client/client'
+require 'nxt_http_client/client/batch_patch'
 require 'nxt_http_client/error'
 
 module NxtHttpClient

--- a/lib/nxt_http_client.rb
+++ b/lib/nxt_http_client.rb
@@ -12,6 +12,7 @@ require 'nxt_http_client/fire_callbacks'
 require 'nxt_http_client/client_dsl'
 require 'nxt_http_client/client'
 require 'nxt_http_client/client/batch_patch'
+require 'nxt_http_client/batch_execution'
 require 'nxt_http_client/error'
 
 module NxtHttpClient

--- a/lib/nxt_http_client/batch_execution.rb
+++ b/lib/nxt_http_client/batch_execution.rb
@@ -1,5 +1,5 @@
 module NxtHttpClient
-  def self.execute_in_batch(*client_instances, ignore_around_callbacks: false)
+  def self.execute_in_batch(*client_instances, ignore_around_callbacks: false, raise_errors: true)
     client_map = Hash.new do |hash, key|
       hash[key] = { request: nil, error: nil, result: nil }
     end
@@ -20,7 +20,7 @@ module NxtHttpClient
     hydra.run
 
     client_map.map do |client, response_data|
-      client.finish(response_data[:request], response_data[:result], response_data[:error])
+      client.finish(response_data[:request], response_data[:result], response_data[:error], raise_errors: raise_errors)
     end
   end
 end

--- a/lib/nxt_http_client/batch_execution.rb
+++ b/lib/nxt_http_client/batch_execution.rb
@@ -1,0 +1,26 @@
+module NxtHttpClient
+  def self.execute_in_batch(*client_instances, ignore_around_callbacks: false)
+    client_map = Hash.new do |hash, key|
+      hash[key] = { request: nil, error: nil, result: nil }
+    end
+
+    client_instances.each do |client|
+      client.singleton_class.include(NxtHttpClient::Client::BatchPatch)
+      client.assign_batch_data(client_map[client], ignore_around_callbacks)
+    end
+
+    hydra = Typhoeus::Hydra.new
+
+    client_instances.each do |client|
+      client.call.tap do |request|
+        hydra.queue(request)
+      end
+    end
+
+    hydra.run
+
+    client_map.map do |client, response_data|
+      client.finish(response_data[:request], response_data[:result], response_data[:error])
+    end
+  end
+end

--- a/lib/nxt_http_client/client/batch_patch.rb
+++ b/lib/nxt_http_client/client/batch_patch.rb
@@ -38,11 +38,17 @@ module NxtHttpClient
         request
       end
 
-      def finish(request, result, error)
+      def finish(request, result, error, raise_errors: true)
         result = run_after_fire_callbacks(request, request.response, result, error)
-        result || (raise error if error)
 
-        result
+        case [error, raise_errors]
+        in [nil, _]
+          result
+        in [_, true]
+          raise error
+        in [_, false]
+          error
+        end
       end
     end
   end

--- a/lib/nxt_http_client/client/batch_patch.rb
+++ b/lib/nxt_http_client/client/batch_patch.rb
@@ -1,0 +1,49 @@
+module NxtHttpClient
+  class Client
+    module BatchPatch
+      attr_reader :callback_map, :ignore_around_callbacks
+
+      def assign_batch_data(callback_map, ignore_around_callbacks)
+        @callback_map = callback_map
+        @ignore_around_callbacks = ignore_around_callbacks
+      end
+
+      def fire(url = '', **opts, &block)
+        response_handler = build_response_handler(opts[:response_handler], &block)
+        request = build_request(url, **opts.except(:response_handler))
+        callback_map[:request] = request
+
+        setup_on_headers_callback(request, response_handler)
+        setup_on_body_callback(request, response_handler)
+
+        request.on_complete do |response|
+          callback_map[:result] = callback_or_response(response, response_handler)
+        rescue StandardError => e
+          callback_map[:error] = e
+        end
+
+        if callbacks.any_around_callbacks? && ignore_around_callbacks != true
+          raise(
+            ArgumentError,
+            <<~TXT
+              `around_fire` callbacks are not supported when firing batches. \
+              Pass `ignore_around_callbacks: true` to `execute_in_batch` \
+              in order to acknowledge and muffle this.
+            TXT
+          )
+        end
+
+        run_before_fire_callbacks(request, response_handler)
+
+        request
+      end
+
+      def finish(request, result, error)
+        result = run_after_fire_callbacks(request, request.response, result, error)
+        result || (raise error if error)
+
+        result
+      end
+    end
+  end
+end

--- a/lib/nxt_http_client/fire_callbacks.rb
+++ b/lib/nxt_http_client/fire_callbacks.rb
@@ -30,6 +30,10 @@ module NxtHttpClient
       end
     end
 
+    def any_around_callbacks?
+      registry.resolve(:around).any?
+    end
+
     def any_after_callbacks?
       registry.resolve(:after).any?
     end

--- a/lib/nxt_http_client/version.rb
+++ b/lib/nxt_http_client/version.rb
@@ -1,3 +1,3 @@
 module NxtHttpClient
-  VERSION = "1.0.5"
+  VERSION = "1.1.0"
 end

--- a/lib/nxt_http_client/version.rb
+++ b/lib/nxt_http_client/version.rb
@@ -1,3 +1,3 @@
 module NxtHttpClient
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end

--- a/spec/batch_execution_spec.rb
+++ b/spec/batch_execution_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe 'batch execution' do
+  let(:client_classes) do
+    3.times.map do |iteration|
+      klass = Class.new(NxtHttpClient::Client)
+
+      klass.class_exec(url) do |get_url|
+        define_method(:call) do
+          get(get_url) do |handler|
+            handler.on(:success) do |_response|
+              "response in client #{iteration + 1}"
+            end
+          end
+        end
+
+        configure do |config|
+          config.base_url = nil
+        end
+      end
+
+      klass
+    end
+  end
+
+  let(:client_one) { client_classes[0].new }
+  let(:client_two) { client_classes[1].new }
+  let(:client_three) { client_classes[2].new }
+
+  let(:ignore_around_callbacks) { false }
+  let(:url) { http_stats_url('200') }
+
+  subject do
+    NxtHttpClient.execute_in_batch(client_three, client_one, client_two, ignore_around_callbacks: ignore_around_callbacks)
+  end
+
+  it 'executes multiple requests in batch and preserves the order of returned responses', :vcr_cassette do
+    expect(subject).to eq(['response in client 3', 'response in client 1', 'response in client 2'])
+  end
+end

--- a/spec/batch_execution_spec.rb
+++ b/spec/batch_execution_spec.rb
@@ -3,11 +3,25 @@ RSpec.describe 'batch execution' do
     3.times.map do |iteration|
       klass = Class.new(NxtHttpClient::Client)
 
-      klass.class_exec(url) do |get_url|
+      klass.class_exec(iteration) do |current_iteration|
+        attr_reader :specified_url
+
+        def initialize(url)
+          @specified_url = url
+        end
+
         define_method(:call) do
-          get(get_url) do |handler|
+          get(specified_url) do |handler|
             handler.on(:success) do |_response|
-              "response in client #{iteration + 1}"
+              "response in client #{current_iteration + 1}"
+            end
+
+            handler.on(400) do |_response|
+              raise StandardError, '400 error'
+            end
+
+            handler.on(404) do |_response|
+              raise StandardError, '404 error'
             end
           end
         end
@@ -21,18 +35,47 @@ RSpec.describe 'batch execution' do
     end
   end
 
-  let(:client_one) { client_classes[0].new }
-  let(:client_two) { client_classes[1].new }
-  let(:client_three) { client_classes[2].new }
+  let(:client_one) { client_classes[0].new(http_stats_url('200')) }
+  let(:client_two) { client_classes[1].new(http_stats_url('200')) }
+  let(:client_three) { client_classes[2].new(http_stats_url('200')) }
 
   let(:ignore_around_callbacks) { false }
+  let(:raise_errors) { true }
   let(:url) { http_stats_url('200') }
 
   subject do
-    NxtHttpClient.execute_in_batch(client_three, client_one, client_two, ignore_around_callbacks: ignore_around_callbacks)
+    NxtHttpClient.execute_in_batch(
+      client_three,
+      client_one,
+      client_two,
+      ignore_around_callbacks: ignore_around_callbacks,
+      raise_errors: raise_errors
+    )
   end
 
   it 'executes multiple requests in batch and preserves the order of returned responses', :vcr_cassette do
     expect(subject).to eq(['response in client 3', 'response in client 1', 'response in client 2'])
+  end
+
+  context 'when one of the requests raises an error' do
+    let(:client_one) { client_classes[0].new(http_stats_url('400')) }
+    let(:client_two) { client_classes[1].new(http_stats_url('404')) }
+    let(:client_three) { client_classes[2].new(http_stats_url('200')) }
+
+    context 'with raise_errors argument set to true', :vcr_cassette do
+      let(:raise_errors) { true }
+
+      it 'executes the requests and raises the first encountered error' do
+        expect { subject }.to raise_error(StandardError, /400 error/)
+      end
+    end
+
+    context 'with raise_errors argument set to false', :vcr_cassette do
+      let(:raise_errors) { false }
+
+      it 'executes the requests and returns the errors as members of the response array' do
+        expect(subject).to contain_exactly('response in client 3', instance_of(StandardError), instance_of(StandardError))
+      end
+    end
   end
 end

--- a/spec/batch_patch_spec.rb
+++ b/spec/batch_patch_spec.rb
@@ -1,0 +1,135 @@
+RSpec.describe NxtHttpClient::Client::BatchPatch do
+  let(:client_one_class) do
+    Class.new(NxtHttpClient::Client) do
+      attr_reader :cache
+
+      def initialize
+        @cache = []
+      end
+
+      configure do |config|
+        config.base_url = nil
+      end
+
+      response_handler(NxtHttpClient::ResponseHandler.new) do |handler|
+        handler.on(200) do |_response|
+          'response in client 1'
+        end
+      end
+
+      before_fire do |_client, _request, _response_handler|
+        cache << 'before fire callback'
+      end
+
+      after_fire do |_client, _request, _response, result, _error|
+        cache << 'after fire callback'
+        result
+      end
+    end
+  end
+
+  let(:client_two_class) do
+    Class.new(NxtHttpClient::Client) do
+      attr_reader :cache
+
+      def initialize
+        @cache = []
+      end
+
+      configure do |config|
+        config.base_url = nil
+      end
+
+      response_handler(NxtHttpClient::ResponseHandler.new) do |handler|
+        handler.on(200) do |_response|
+          'response in client 2'
+        end
+      end
+
+      before_fire do |_client, _request, _response_handler|
+        cache << 'before fire callback'
+      end
+
+      after_fire do |_client, _request, _response, result, _error|
+        cache << 'after fire callback'
+        result
+      end
+    end
+  end
+
+  subject do
+    client_instances = [client_one, client_two]
+
+    client_map = Hash.new do |hash, key|
+      hash[key] = { request: nil, error: nil, result: nil }
+    end
+
+    client_instances.each do |client|
+      client.assign_batch_data(client_map[client], ignore_around_callbacks)
+    end
+
+    hydra = Typhoeus::Hydra.new
+
+    client_instances.each do |client|
+      client.get(url).tap do |request|
+        hydra.queue(request)
+      end
+    end
+
+    hydra.run
+
+    client_map.map do |client, response_data|
+      client.finish(response_data[:request], response_data[:result], response_data[:error])
+    end
+  end
+
+  let(:client_one) { client_one_class.new }
+  let(:client_two) { client_two_class.new }
+
+  let(:ignore_around_callbacks) { false }
+  let(:url) { http_stats_url('200') }
+
+  before do
+    [client_one, client_two].each { _1.singleton_class.include(NxtHttpClient::Client::BatchPatch) }
+  end
+
+  context 'when around_fire callbacks are not defined', :vcr_cassette do
+    it 'executes multiple requests in batch' do
+      expect(subject).to eq(['response in client 1', 'response in client 2'])
+      [client_one, client_two].each do |client|
+        expect(client.cache).to eq(['before fire callback', 'after fire callback'])
+      end
+    end
+  end
+
+  context 'when around_fire callbacks are defined' do
+    before do
+      [[client_one_class, '1'], [client_two_class, '2']].each do |client_class, client_id|
+        client_class.class_eval do
+          around_fire do |_client, _request, _response_handler, _fire|
+            callback_map["client #{client_id}"] << 'around fire callback'
+          end
+        end
+      end
+    end
+
+    context 'when callback ignore is not acknowledged', :vcr_cassette do
+      let(:ignore_around_callbacks) { false }
+
+      it 'does not allow execution' do
+        expect { subject }.to raise_error(ArgumentError, /`around_fire` callbacks are not supported when firing batches/)
+      end
+    end
+
+    context 'when callback ignore is acknowledged', :vcr_cassette do
+      let(:ignore_around_callbacks) { true }
+
+      it 'allows execution without running around callbacks' do
+        expect(subject).to eq(['response in client 1', 'response in client 2'])
+        [client_one, client_two].each do |client|
+          expect(client.cache).to eq(['before fire callback', 'after fire callback'])
+        end
+      end
+    end
+  end
+end

--- a/spec/batch_patch_spec.rb
+++ b/spec/batch_patch_spec.rb
@@ -81,10 +81,11 @@ RSpec.describe NxtHttpClient::Client::BatchPatch do
 
   context 'when around_fire callbacks are defined' do
     before do
-      client_classes.each_with_index do |client_class, client_id|
+      client_classes.each_with_index do |client_class, _client_id|
         client_class.class_eval do
-          around_fire do |_client, _request, _response_handler, _fire|
-            callback_map["client #{client_id + 1}"] << 'around fire callback'
+          around_fire do |_client, _request, _response_handler, fire|
+            cache << 'around fire callback'
+            fire.call
           end
         end
       end

--- a/spec/fixtures/vcr_cassettes/batch_execution_spec/batch_execution/executes_multiple_requests_in_batch_and_preserves_the_order_of_returned_responses.yml
+++ b/spec/fixtures/vcr_cassettes/batch_execution_spec/batch_execution/executes_multiple_requests_in_batch_and_preserves_the_order_of_returned_responses.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://httpstat.us/200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '6'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 16:44:33 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 200 OK
+  recorded_at: Mon, 03 Apr 2023 16:44:34 GMT
+- request:
+    method: get
+    uri: http://httpstat.us/200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '6'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 16:44:33 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 200 OK
+  recorded_at: Mon, 03 Apr 2023 16:44:34 GMT
+- request:
+    method: get
+    uri: http://httpstat.us/200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '6'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 16:44:33 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 200 OK
+  recorded_at: Mon, 03 Apr 2023 16:44:34 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/batch_execution_spec/batch_execution/when_one_of_the_requests_raises_an_error/with_raise_errors_argument_set_to_false.yml
+++ b/spec/fixtures/vcr_cassettes/batch_execution_spec/batch_execution/when_one_of_the_requests_raises_an_error/with_raise_errors_argument_set_to_false.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://httpstat.us/400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Length:
+      - '15'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 17:33:20 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 400 Bad Request
+  recorded_at: Mon, 03 Apr 2023 17:33:21 GMT
+- request:
+    method: get
+    uri: http://httpstat.us/404
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '13'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 17:33:20 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 404 Not Found
+  recorded_at: Mon, 03 Apr 2023 17:33:21 GMT
+- request:
+    method: get
+    uri: http://httpstat.us/200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '6'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 17:33:20 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 200 OK
+  recorded_at: Mon, 03 Apr 2023 17:33:21 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/batch_execution_spec/batch_execution/when_one_of_the_requests_raises_an_error/with_raise_errors_argument_set_to_true.yml
+++ b/spec/fixtures/vcr_cassettes/batch_execution_spec/batch_execution/when_one_of_the_requests_raises_an_error/with_raise_errors_argument_set_to_true.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://httpstat.us/400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Length:
+      - '15'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 17:32:54 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 400 Bad Request
+  recorded_at: Mon, 03 Apr 2023 17:32:55 GMT
+- request:
+    method: get
+    uri: http://httpstat.us/200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '6'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 17:32:54 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 200 OK
+  recorded_at: Mon, 03 Apr 2023 17:32:55 GMT
+- request:
+    method: get
+    uri: http://httpstat.us/404
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '13'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 17:32:54 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 404 Not Found
+  recorded_at: Mon, 03 Apr 2023 17:32:55 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/batch_patch_spec/NxtHttpClient_Client_BatchPatch/when_a_request_raises_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/batch_patch_spec/NxtHttpClient_Client_BatchPatch/when_a_request_raises_an_error.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://httpstat.us/400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Length:
+      - '15'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 17:19:59 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 400 Bad Request
+  recorded_at: Mon, 03 Apr 2023 17:19:59 GMT
+- request:
+    method: get
+    uri: http://httpstat.us/200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '6'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 17:19:59 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 200 OK
+  recorded_at: Mon, 03 Apr 2023 17:19:59 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/batch_patch_spec/NxtHttpClient_Client_BatchPatch/when_around_fire_callbacks_are_defined/when_callback_ignore_is_acknowledged.yml
+++ b/spec/fixtures/vcr_cassettes/batch_patch_spec/NxtHttpClient_Client_BatchPatch/when_around_fire_callbacks_are_defined/when_callback_ignore_is_acknowledged.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://httpstat.us/200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '6'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 08:27:13 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 200 OK
+  recorded_at: Mon, 03 Apr 2023 08:27:14 GMT
+- request:
+    method: get
+    uri: http://httpstat.us/200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '6'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 08:27:13 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 200 OK
+  recorded_at: Mon, 03 Apr 2023 08:27:14 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/batch_patch_spec/NxtHttpClient_Client_BatchPatch/when_around_fire_callbacks_are_not_defined.yml
+++ b/spec/fixtures/vcr_cassettes/batch_patch_spec/NxtHttpClient_Client_BatchPatch/when_around_fire_callbacks_are_not_defined.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://httpstat.us/200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '6'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 08:27:13 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 200 OK
+  recorded_at: Mon, 03 Apr 2023 08:27:13 GMT
+- request:
+    method: get
+    uri: http://httpstat.us/200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '6'
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 03 Apr 2023 08:27:13 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ARRAffinity=007aae37af811650ee54291e49583a41d199b8091f1e3d603d61efeda707f751;Path=/;HttpOnly;Domain=httpstat.us
+      Request-Context:
+      - appId=cid-v1:3548b0f5-7f75-492f-82bb-b6eb0e864e53
+    body:
+      encoding: ASCII-8BIT
+      string: 200 OK
+  recorded_at: Mon, 03 Apr 2023 08:27:13 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
Typhoeus provides an interface to execute multiple requests concurrently through `Typhoeus::Hydra`. This helps alleviate the necessity to spawn threads or fibers, since concurrency is handled outside of the Ruby VM.

This PR provides a way to utilise that interface without breaking backward compatibility with existing `Client`s, and can be used with these clients without a need to refactor.

The only limitation is that `around_fire` callbacks can not be executed, since there's no granular control over the execution of each particular request in a batch. If any are defined, the batch won't run unless the developer explicitly acknowledges this by passing a `ignore_around_callbacks: true` argument. When done so, existing around_fire callback **will not** be run.
However, `before` and `after` callbacks will be run just like with the single request.

The interface itself is done via a patch, and the way I see it, it's the only quick way that doesn't break compatibility and doesn't require a big refactoring.

**Usage example:**
```ruby
# Fully compatible with any descendants of `NxtHttpClient::Client` (in case the client provides a `#call` method),
# and as a consequence with any `NxtClients::Client`s.
responses = NxtHttpClient.execute_in_batch(
  NxtClients::InsuranceService::ClientA.new,
  NxtClients::DocumentService::ClientB.new,
  NxtClients::ApplicationService::ClientC.new
)
```
