### PR TITLE
Handle response not responding to :code method

### DIFF
--- a/lib/nxt_http_client/error.rb
+++ b/lib/nxt_http_client/error.rb
@@ -41,7 +41,9 @@ module NxtHttpClient
     end
 
     def response_code
-      response.code || 0
+      return response.code if response.respond_to?(:code)
+      
+      0
     end
 
     def request

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe NxtHttpClient::Error do
       expect(subject.response_options).to eq({})
       expect(subject.response_headers).to eq({})
       expect(subject.response_content_type).to be_nil
-      expect(subject.timed_out?).to be(false)
-      expect(subject.status_message).to be(nil)
+      expect(subject.timed_out?).to be_falsey
+      expect(subject.status_message).to be_nil
+      expect(subject.response_code).to be_zero
     end
   end
 

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -19,6 +19,26 @@ RSpec.describe NxtHttpClient::Error do
     end
   end
 
+  context 'when the response is a empty string' do
+    subject do
+      described_class.new('')
+    end
+
+    it 'responds to all methods' do
+      expect(subject.body).to be_nil
+      expect(subject.url).to eq("/dev/null")
+      expect(subject.request).to be_a(Typhoeus::Request)
+      expect(subject.request_options).to eq({})
+      expect(subject.request_headers).to eq({})
+      expect(subject.response_options).to eq({})
+      expect(subject.response_headers).to eq({})
+      expect(subject.response_content_type).to be_nil
+      expect(subject.timed_out?).to be_falsey
+      expect(subject.status_message).to be_nil
+      expect(subject.response_code).to be_zero
+    end
+  end
+
   context 'when initialized with a real response' do
     let(:client) do
       Class.new(NxtHttpClient::Client) do


### PR DESCRIPTION
To test blank responses in our codebase we need to be able to mock an empty response. 

Currently, implementation throws a no method error when the response is a `String` object and therefore doesn't respond to the `code` method. 

![Screenshot 2024-02-22 at 13 34 24](https://github.com/nxt-insurance/nxt_http_client/assets/23486776/8a303cd6-0c67-484c-86ba-81227daf660e)
