### PR TITLE
Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.0.1 2024-02-22
+- Handle response code for empty strings and blank responses
+
 # v2.0.0 2023-08-31
 - Add simpler initialization interface for one-off clients
 - Add helpers for common config options

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_http_client (2.0.0)
+    nxt_http_client (2.0.1)
       activesupport (< 8.0)
       nxt_registry
       typhoeus
@@ -9,27 +9,37 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.7.2)
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
     coderay (1.1.3)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
+    drb (2.2.0)
+      ruby2_keywords
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    ffi (1.15.5)
+    ffi (1.16.3)
     hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.19.0)
+    minitest (5.22.2)
+    mutex_m (0.2.0)
     nxt_registry (0.3.10)
       activesupport
     nxt_vcr_harness (0.1.4)
@@ -60,8 +70,9 @@ GEM
     rspec-support (3.12.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
+    ruby2_keywords (0.0.5)
     timecop (0.9.6)
-    typhoeus (1.4.0)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -280,7 +280,13 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ### Github Package Registry
 
-To release a new version, update the version number in `version.rb`, and then run `bin/release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to the github package registry.
+To release a new version follow the steps strictly: 
+
+- Commit all your feature changes
+- Update the version number in `version.rb`,
+- Run bundle install to update the Gemfile.lock
+- Open your PR and get it approved and merged
+- Checkout to main and then run `bin/release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to the github package registry.
 
 Before releasing a new version, make sure you have authenticated with the Github package registry. To do so, create a personal access token ([in your Github account settings](https://github.com/settings/tokens))
 
@@ -312,8 +318,13 @@ Add to `~/.gem/credentials` (create if it doesn't exist):
 :rubygems: <your Rubygems API key>
 ```
 
-To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`,
-which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To release a new version follow the steps strictly: 
+
+- Commit all your feature changes
+- Update the version number in `version.rb`,
+- Run bundle install to update the Gemfile.lock
+- Open your PR and get it approved and merged
+- And then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -278,21 +278,22 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Releasing
 
-First, if you don't want to always log in with your RubyGems password, 
-you can create an API key on Rubygems.org, and then run:
+To release a new version, update the version number in `version.rb`, and then run `bin/release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to the github package registry.
 
-```shell
-bundle config set --local gem.push_key rubygems
+Before releasing a new version, make sure you have authenticated with the Github package registry. To do so, create a personal access token ([in your Github account settings](https://github.com/settings/tokens))
+
+Then create or add to the existing file ~/.gem/credentials, replacing `TOKEN` with your personal access token.
+
+```
+---
+:github: Bearer TOKEN
 ```
 
-Add to `~/.gem/credentials` (create if it doesn't exist):
+Then run 
 
-```shell
-:rubygems: <your Rubygems API key>
+```sh
+bundle config set --local gem.push_key github
 ```
-
-To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`,
-which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,30 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Releasing
 
-### Github Package Registry
+### RubyGems 
+
+First, if you don't want to always log in with your RubyGems password, 
+you can create an API key on Rubygems.org, and then run:
+
+```shell
+bundle config set --local gem.push_key rubygems
+```
+
+Add to `~/.gem/credentials` (create if it doesn't exist):
+
+```shell
+:rubygems: <your Rubygems API key>
+```
+
+To release a new version follow the steps strictly: 
+
+- Commit all your feature changes
+- Update the version number in `version.rb`,
+- Run bundle install to update the Gemfile.lock
+- Open your PR and get it approved and merged
+- And then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+### Github Package Registry 
 
 To release a new version follow the steps strictly: 
 
@@ -302,29 +325,6 @@ Then run
 ```sh
 bundle config set --local gem.push_key github
 ```
-
-### RubyGems 
-
-First, if you don't want to always log in with your RubyGems password, 
-you can create an API key on Rubygems.org, and then run:
-
-```shell
-bundle config set --local gem.push_key rubygems
-```
-
-Add to `~/.gem/credentials` (create if it doesn't exist):
-
-```shell
-:rubygems: <your Rubygems API key>
-```
-
-To release a new version follow the steps strictly: 
-
-- Commit all your feature changes
-- Update the version number in `version.rb`,
-- Run bundle install to update the Gemfile.lock
-- Open your PR and get it approved and merged
-- And then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Releasing
 
+### Github Package Registry
+
 To release a new version, update the version number in `version.rb`, and then run `bin/release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to the github package registry.
 
 Before releasing a new version, make sure you have authenticated with the Github package registry. To do so, create a personal access token ([in your Github account settings](https://github.com/settings/tokens))
@@ -294,6 +296,24 @@ Then run
 ```sh
 bundle config set --local gem.push_key github
 ```
+
+### RubyGems 
+
+First, if you don't want to always log in with your RubyGems password, 
+you can create an API key on Rubygems.org, and then run:
+
+```shell
+bundle config set --local gem.push_key rubygems
+```
+
+Add to `~/.gem/credentials` (create if it doesn't exist):
+
+```shell
+:rubygems: <your Rubygems API key>
+```
+
+To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`,
+which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/bin/release
+++ b/bin/release
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-GEM_VERSION=$(ruby -e '$LOAD_PATH << File.join(File.dirname(__FILE__), "lib"); require "nxt_http_client/version"; print NxtClients::VERSION')
+GEM_VERSION=$(ruby -e '$LOAD_PATH << File.join(File.dirname(__FILE__), "lib"); require "nxt_http_client/version"; print NxtHttpClient::VERSION')
 
 gem build nxt_http_client.gemspec
 

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+GEM_VERSION=$(ruby -e '$LOAD_PATH << File.join(File.dirname(__FILE__), "lib"); require "nxt_http_client/version"; print NxtClients::VERSION')
+
+gem build nxt_http_client.gemspec
+
+if [ ! -d "pkg" ]; then
+  mkdir pkg
+fi
+
+mv nxt_http_client-$GEM_VERSION.gem pkg/nxt_http_client-$GEM_VERSION.gem
+
+git tag -m "Release $GEM_VERSION" -a v$GEM_VERSION HEAD
+git push origin --tags
+
+gem push --key github --host https://rubygems.pkg.github.com/nxt-insurance pkg/nxt_http_client-$GEM_VERSION.gem

--- a/lib/nxt_http_client/version.rb
+++ b/lib/nxt_http_client/version.rb
@@ -1,3 +1,3 @@
 module NxtHttpClient
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
The PR used to release the v2.0.1 which also adds a new release script following [NxtClients](https://github.com/nxt-insurance/nxt_clients) example. 


Suggestion: 

We could automatically open a PR for the release through the Release Script and also create the releases on Github to follow the current gem version in the registry. 


