### PR TITLE
Remove AS version constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,34 @@
 PATH
   remote: .
   specs:
-    nxt_http_client (2.1.0)
-      activesupport (< 8.0)
+    nxt_http_client (2.1.1)
+      activesupport
       nxt_registry
       typhoeus
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.4)
+    activesupport (8.0.0)
       base64
+      benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
+    benchmark (0.4.0)
     bigdecimal (3.1.8)
     coderay (1.1.3)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crack (1.0.0)
       bigdecimal
@@ -37,11 +41,11 @@ GEM
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     hashdiff (1.1.0)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
+    logger (1.6.1)
     method_source (1.1.0)
-    minitest (5.23.1)
-    mutex_m (0.2.0)
+    minitest (5.25.2)
     nxt_registry (0.3.10)
       activesupport
     nxt_vcr_harness (0.2.0)
@@ -73,12 +77,14 @@ GEM
     rspec-support (3.13.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
+    securerandom (0.3.2)
     strscan (3.1.0)
     timecop (0.9.9)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (1.0.2)
     vcr (6.2.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/lib/nxt_http_client/version.rb
+++ b/lib/nxt_http_client/version.rb
@@ -1,3 +1,3 @@
 module NxtHttpClient
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/nxt_http_client.gemspec
+++ b/nxt_http_client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'typhoeus'
-  spec.add_dependency 'activesupport', '< 8.0'
+  spec.add_dependency 'activesupport'
   spec.add_dependency 'nxt_registry'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
This PR relaxes the AS version constraint, which prevents `nxt_core` from bumping the Rails edge appraisal group.